### PR TITLE
#6 パスワードの設定条件を強化する修正

### DIFF
--- a/classes/Vtiger/connectors/Portal.php
+++ b/classes/Vtiger/connectors/Portal.php
@@ -261,6 +261,26 @@ class Vtiger_Portal_Connector extends Vtiger_PortalBase_Connector {
 	public function changePassword($record) {
 		$username = Portal_Session::get('username');
 		$this->auth = array('Authorization' => 'Basic '.base64_encode($username.':'.$password));
+		if(strlen($record['newPassword'])<=8){		
+			$error_keyisweak = array(
+				"code" => '1414',
+				"message" => "Password is not long enough. Please increase the length to at least 8 characters.",
+			);	
+			return $error_keyisweak;
+		}else if(!(preg_match('/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\-+=^$*.\[\]{}()?\"!@#%&\/\\\\,><\':;|_~`\-+=])(?!.*[^a-zA-Z\d\-+=^$*.\[\]{}()?\"!@#%&\/\\\\,><\':;|_~`]).+$/', $record['newPassword']))){
+			$error_keyisweak = array(
+				"code" => '1414',
+				"message" => "The password is not strong enough. Please use at least one lowercase alphabet, one uppercase alphabet, one number and one symbol.",
+			);
+			return $error_keyisweak;
+		}
+		if($record['oldPassword'] == $record['newPassword']){
+			$error_keyisweak = array(
+				"code" => '1414',
+				"message" => "The same password as the previous one cannot be used.",
+			);
+			return $error_keyisweak;
+		}
 
 		$params = array(
 			'_operation' => 'ChangePassword',


### PR DESCRIPTION
##  関連Issue / Related Issue
<!-- 関連Issueをfix #(番号)で記述 -->
- fix #6 

##  不具合の内容 / Bug
1. パスワードが単純なものでも設定できてしまう。

##  原因 / Cause
1. 特に制限を設定していなかった。
##  変更内容 / Details of Change
1. パスワードの文字数を８文字以下の時は受け付けないように設定。
2. 半角小文字英字、半角大文字英字、半角数字、特殊記号をそれぞれ一つ以上使わないといけないよう設定。

## スクリーンショット / Screenshot
![image](https://user-images.githubusercontent.com/95267222/181191028-c0ccb6b0-cb97-4273-bd62-447e011fef4e.png)

## 影響範囲  / Affected Area
パスワード変更の個所。
## チェックリスト / Check List
<!-- カッコ内にxを記入 -->
- [x] 自らテストを行った
- [x] 不必要な変更が無い
- [x] 影響範囲の検討を行った

## 備考 / Remarks
